### PR TITLE
Special case mappings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,9 @@ jobs:
           command: |
             if [ ! -d "${HOME}/ant" ]
             then
-                curl -o ${HOME}/ant.tar.bz2 http://mirror.csclub.uwaterloo.ca/apache//ant/binaries/apache-ant-1.10.2-bin.tar.bz2
+                curl -o ${HOME}/ant.tar.bz2 http://mirror.csclub.uwaterloo.ca/apache//ant/binaries/apache-ant-1.10.5-bin.tar.bz2
                 tar jxf ${HOME}/ant.tar.bz2 -C ${HOME}
-                mv ${HOME}/apache-ant-1.10.2 ${HOME}/ant
+                mv ${HOME}/apache-ant-1.10.5 ${HOME}/ant
             fi
 
       - save_cache:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ca.orchard-labs/morph "1.0.2-SNAPSHOT"
+(defproject ca.orchard-labs/morph "1.1.0"
   :description "A small collection of useful transformations"
   :url "http://github.com/orchard-labs/morph"
   :license {:name "Eclipse Public License"

--- a/src/morph/core.clj
+++ b/src/morph/core.clj
@@ -39,7 +39,14 @@
                                       non-map-collection
                                       specter/ALL))))
 
+(defn trap-mappings
+  [mappings]
+  (fn [v]
+    (or (get mappings v) v)))
+
 (defn transform-keys
+  ([pred f mappings m]
+   (transform-keys pred (comp (trap-mappings mappings) f) m))
   ([pred f m]
    (specter/transform [RECURSIVE-MAP-KEYS pred] f (have map? m)))
   ([f m]

--- a/test/morph/core_test.clj
+++ b/test/morph/core_test.clj
@@ -4,26 +4,44 @@
             [clj-time.core :as t]))
 
 (deftest keys->kebab-case-test
-  (is (= {:foo-bar 1
-          :foo-bor 2
-          :foo-bur 3}
-         (morph/keys->kebab-case {:fooBar  1
-                                  :foo_bor 2
-                                  :foo-bur 3})))
+  (testing "1-arity"
+    (is (= {:foo-bar 1
+            :foo-bor 2
+            :foo-bur 3}
+           (morph/keys->kebab-case {:fooBar  1
+                                    :foo_bor 2
+                                    :foo-bur 3})))
 
-  (is (= {:foo-bar {:foo-bor 1}}
-         (morph/keys->kebab-case {:foo_bar {:fooBor 1}}))))
+    (is (= {:foo-bar {:foo-bor 1}}
+           (morph/keys->kebab-case {:foo_bar {:fooBor 1}}))))
+
+  (testing "2-arity"
+    (is (not= {:phone-number-e164 "not a thing"}
+              (morph/keys->kebab-case {:phoneNumberE164 "not a thing"})))
+
+    (is (= {:phone-number-e164 "not a thing"}
+           (morph/keys->kebab-case {:phone-number-e-164 :phone-number-e164}
+                                   {:phoneNumberE164 "not a thing"})))))
 
 (deftest keys->camelCase-test
-  (is (= {:fooBar 1
-          :fooBor 2
-          :fooBur 3}
-         (morph/keys->camelCase {:fooBar  1
-                                 :foo_bor 2
-                                 :foo-bur 3})))
+  (testing "1-arity"
+    (is (= {:fooBar 1
+            :fooBor 2
+            :fooBur 3}
+           (morph/keys->camelCase {:fooBar  1
+                                   :foo_bor 2
+                                   :foo-bur 3})))
 
-  (is (= {:fooBar {:fooBor 1}}
-         (morph/keys->camelCase {:foo_bar {:foo-bor 1}}))))
+    (is (= {:fooBar {:fooBor 1}}
+           (morph/keys->camelCase {:foo_bar {:foo-bor 1}}))))
+
+  (testing "2-arity"
+    (is (not= {:x_e10_activationType "not a thing"}
+              (morph/keys->camelCase {:x-e10-activation-type "not a thing"})))
+
+    (is (= {:x_e10_activationType "not a thing"}
+           (morph/keys->camelCase {:xE10ActivationType :x_e10_activationType}
+                                  {:x-e10-activation-type "not a thing"})))))
 
 (deftest recursive-navigators-test
   (let [now      (t/now)


### PR DESCRIPTION
This supplies an extra 2-arity version of the `keys->*` functions, with corresponding `transform-keys` 4-arity implementation which takes a map of special case transformation based on the transformation output.

See the tests for examples.